### PR TITLE
Removing Django 1.7 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=master
@@ -16,8 +15,6 @@ matrix:
       env: DJANGO=1.9
     - python: "3.3"
       env: DJANGO=master
-    - python: "3.5"
-      env: DJANGO=1.7
 install:
   - pip install tox coveralls
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -6,16 +6,15 @@ exclude = migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.7,1.8,1.9,master},
-    py33-{1.7,1.8},
-    py34-{1.7,1.8,1.9,master},
+    py27-{1.8,1.9,master},
+    py33-{1.8},
+    py34-{1.8,1.9,master},
     py35-{1.8,1.9,master}
 
 [testenv]
 deps =
     coverage == 4.0.2
     flake8 == 2.5.0
-    1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     master: https://github.com/django/django/tarball/master


### PR DESCRIPTION
Simply removing Django 1.7 from the Travis and tox configurations.