### PR TITLE
Fix Django 2.0 deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,24 +39,12 @@ jobs:
         environment:
           - TOXENV=checkqa
           - UPLOAD_COVERAGE=0
-  py27dj18:
-    <<: *common
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          TOXENV=py27-dj18
   py27dj111:
     <<: *common
     docker:
       - image: circleci/python:2.7
         environment:
           TOXENV=py27-dj111
-  py34dj18:
-    <<: *common
-    docker:
-      - image: circleci/python:3.4
-        environment:
-          TOXENV=py34-dj18
   py34dj111:
     <<: *common
     docker:
@@ -69,12 +57,6 @@ jobs:
       - image: circleci/python:3.4
         environment:
           TOXENV=py34-dj20
-  py35dj18:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV=py35-dj18
   py35dj111:
     <<: *common
     docker:
@@ -105,12 +87,9 @@ workflows:
   test:
     jobs:
       - lint
-      - py27dj18
       - py27dj111
-      - py34dj18
       - py34dj111
       - py34dj20
-      - py35dj18
       - py35dj111
       - py35dj20
       - py36dj111

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,19 +86,17 @@ Here is an example of these rules applied:
     # non-from imports go first then from style import in their own group
     import csv
     
-    # second set of imports are Django imports with contrib in their own
-    # group.
+    # second set of imports are Django imports
+    from django.contrib.auth.models import User
     from django.db import models
+    from django.urls import reverse
     from django.utils import timezone
     from django.utils.translation import ugettext_lazy as _
-    
-    from django.contrib.auth.models import User
     
     # third set of imports are external apps (if applicable)
     from tagging.fields import TagField
     
     # fourth set of imports are local apps
-    from .compat import reverse
     from .fields import MarkupField
     
     

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ for any site wanting announcements for it's users.
 
 #### Supported Django and Python versions
 
-Python \ Django | 1.8 | 1.11 | 2.0
---------------- | --- | ---- | ---
-2.7 | * | * |   |
-3.4 | * | * | * |
-3.5 | * | * | * |
-3.6 |   | * | * |
+Python \ Django | 1.11 | 2.0
+--------------- | ---- | ---
+            2.7 |  *   | 
+            3.4 |  *   |  *
+            3.5 |  *   |  *
+            3.6 |  *   |  *
 
 #### Features
 
@@ -221,6 +221,7 @@ and which are not dismissed.
 ### 2.1.1
 
 * Standardize documentation layout
+* Drop Django v1.8, v1.10 support
 
 ### 2.1
 

--- a/pinax/announcements/auth_backends.py
+++ b/pinax/announcements/auth_backends.py
@@ -8,8 +8,4 @@ class AnnouncementPermissionsBackend(object):
 
     def has_perm(self, user, perm, obj=None):
         if perm == "announcements.can_manage":
-            if callable(getattr(user, "is_authenticated")):
-                # Django v1.8 compatibility
-                return user.is_authenticated() and user.is_staff
-            else:
-                return user.is_authenticated and user.is_staff
+            return user.is_authenticated and user.is_staff

--- a/pinax/announcements/auth_backends.py
+++ b/pinax/announcements/auth_backends.py
@@ -8,4 +8,8 @@ class AnnouncementPermissionsBackend(object):
 
     def has_perm(self, user, perm, obj=None):
         if perm == "announcements.can_manage":
-            return user.is_authenticated() and user.is_staff
+            if callable(getattr(user, "is_authenticated")):
+                # Django v1.8 compatibility
+                return user.is_authenticated() and user.is_staff
+            else:
+                return user.is_authenticated and user.is_staff

--- a/pinax/announcements/compat.py
+++ b/pinax/announcements/compat.py
@@ -1,0 +1,4 @@
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # noqa

--- a/pinax/announcements/compat.py
+++ b/pinax/announcements/compat.py
@@ -1,9 +1,0 @@
-try:
-    from django.urls import reverse, reverse_lazy
-except ImportError:
-    from django.core.urlresolvers import reverse, reverse_lazy  # noqa
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock  # noqa

--- a/pinax/announcements/models.py
+++ b/pinax/announcements/models.py
@@ -1,10 +1,9 @@
 from django.conf import settings
 from django.db import models
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
-
-from django.urls import reverse
 
 
 @python_2_unicode_compatible

--- a/pinax/announcements/models.py
+++ b/pinax/announcements/models.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
-from .compat import reverse
+from django.urls import reverse
 
 
 @python_2_unicode_compatible

--- a/pinax/announcements/templatetags/pinax_announcements_tags.py
+++ b/pinax/announcements/templatetags/pinax_announcements_tags.py
@@ -30,7 +30,7 @@ class AnnouncementsNode(template.Node):
 
         exclusions = request.session.get("excluded_announcements", [])
         exclusions = set(exclusions)
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             for dismissal in request.user.announcement_dismissals.all():
                 exclusions.add(dismissal.announcement.pk)
         else:

--- a/pinax/announcements/tests/tests.py
+++ b/pinax/announcements/tests/tests.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.models import Session
@@ -9,6 +7,7 @@ from django.utils import timezone
 
 from test_plus.test import TestCase
 
+from ..compat import mock
 from ..models import Announcement, Dismissal
 from ..templatetags.pinax_announcements_tags import \
     announcements as announcements_tag

--- a/pinax/announcements/tests/tests.py
+++ b/pinax/announcements/tests/tests.py
@@ -1,12 +1,14 @@
+from unittest import mock
+
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.models import Session
 from django.test import RequestFactory
+from django.urls import reverse
 from django.utils import timezone
 
 from test_plus.test import TestCase
 
-from ..compat import mock, reverse
 from ..models import Announcement, Dismissal
 from ..templatetags.pinax_announcements_tags import \
     announcements as announcements_tag

--- a/pinax/announcements/views.py
+++ b/pinax/announcements/views.py
@@ -31,7 +31,7 @@ class AnnouncementDismissView(SingleObjectMixin, View):
             request.session["excluded_announcements"] = list(excluded)
             status = 200
         elif self.object.dismissal_type == Announcement.DISMISSAL_PERMANENT and \
-                request.user.is_authenticated():
+                request.user.is_authenticated:
             self.object.dismissals.create(user=request.user)
             status = 200
         else:

--- a/pinax/announcements/views.py
+++ b/pinax/announcements/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, View
 from django.views.generic.detail import SingleObjectMixin
@@ -7,7 +8,6 @@ from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
 
 from . import signals
-from .compat import reverse_lazy
 from .forms import AnnouncementForm
 from .models import Announcement
 

--- a/runtests.py
+++ b/runtests.py
@@ -18,10 +18,9 @@ DEFAULT_SETTINGS = dict(
         "pinax.announcements",
         "pinax.announcements.tests"
     ],
-    MIDDLEWARE_CLASSES=[
+    MIDDLEWARE = [
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
-        "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
     ],
     DATABASES={
         "default": {

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
     tests_require=[
         "django-test-plus>=1.0.19",
         "pinax-theme-bootstrap>=7.7.0",
+        "mock>=2.0.0",
     ],
     test_suite="runtests.runtests",
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -46,17 +46,17 @@ Announcements have title and content, with options for filtering their display:
 Supported Django and Python Versions
 ------------------------------------
 
-+---------------+------+------+------+
-| Django\Python |  1.8 | 1.11 |  2.0 |
-+===============+======+======+======+
-| 2.7           |   *  |   *  |      |
-+---------------+------+------+------+
-| 3.4           |   *  |   *  |  *   |
-+---------------+------+------+------+
-| 3.5           |   *  |   *  |  *   |
-+---------------+------+------+------+
-| 3.6           |      |   *  |  *   |
-+---------------+------+------+------+
++---------------+------+------+
+| Django\Python | 1.11 |  2.0 |
++===============+======+======+
+| 2.7           |   *  |      |
++---------------+------+------+
+| 3.4           |   *  |  *   |
++---------------+------+------+
+| 3.5           |   *  |  *   |
++---------------+------+------+
+| 3.6           |   *  |  *   |
++---------------+------+------+
 """
 
 setup(
@@ -76,7 +76,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Django",
-        'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         "Intended Audience :: Developers",
@@ -92,12 +91,11 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=[
-        "django>=1.8",
+        "django>=1.11",
     ],
     tests_require=[
         "django-test-plus>=1.0.19",
         "pinax-theme-bootstrap>=7.7.0",
-        "mock",
     ],
     test_suite="runtests.runtests",
     zip_safe=False

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,9 @@ show_missing = True
 [tox]
 envlist =
     checkqa,
-    py27-dj{18,111}
-    py34-dj{18,111,20}
-    py35-dj{18,111,20}
+    py27-dj{111}
+    py34-dj{111,20}
+    py35-dj{111,20}
     py36-dj{111,20}
 
 [testenv]
@@ -37,7 +37,6 @@ passenv = CI CIRCLECI CIRCLE_*
 deps =
     coverage
     codecov
-    dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12
     dj20: Django<2.1
     master: https://github.com/django/django/tarball/master


### PR DESCRIPTION
User.is_authenticated() is a property, not a method, as of Django v1.10. This was still supported until v2.0 where method usage is deprecated entirely.