### PR TITLE
Avoid extra queries when fetching dismissals

### DIFF
--- a/pinax/announcements/templatetags/pinax_announcements_tags.py
+++ b/pinax/announcements/templatetags/pinax_announcements_tags.py
@@ -31,8 +31,7 @@ class AnnouncementsNode(template.Node):
         exclusions = request.session.get("excluded_announcements", [])
         exclusions = set(exclusions)
         if request.user.is_authenticated:
-            for dismissal in request.user.announcement_dismissals.all():
-                exclusions.add(dismissal.announcement.pk)
+            qs = qs.exclude(dismissals__user=request.user)
         else:
             qs = qs.exclude(members_only=True)
         context[self.as_var] = qs.exclude(pk__in=exclusions)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10727645/61963838-29083300-af92-11e9-847d-045ce998f72f.png)

After:
![image](https://user-images.githubusercontent.com/10727645/61963855-332a3180-af92-11e9-8657-79ebe65f0094.png)
