### PR TITLE
feat: support Django 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV=py36-dj32
+  py36dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV=py36-dj40
   py37dj22:
     <<: *common
     docker:
@@ -86,6 +92,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV=py37-dj32
+  py37dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV=py37-dj40
   py38dj22:
     <<: *common
     docker:
@@ -110,6 +122,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV=py38-dj32
+  py38dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV=py38-dj40
 
 workflows:
   version: 2
@@ -120,11 +138,14 @@ workflows:
       - py36dj30
       - py36dj31
       - py36dj32
+      - py36dj40
       - py37dj22
       - py37dj30
       - py37dj31
       - py37dj32
+      - py37dj40
       - py38dj22
       - py38dj30
       - py38dj31
       - py38dj32
+      - py38dj40

--- a/AUTHORS
+++ b/AUTHORS
@@ -17,4 +17,4 @@ arthur <arthur@wallstreetweb.net>
 Graham Ullrich <graham@flyingcracker.com>
 Mfon Eti-mfon <mfonetimfon@gmail.com>
 Katherine Michel <kthrnmichel@gmail.com>
-
+Agus Makmun <summon.agus@gmail.com>

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Announcements have title and content, with options for filtering their display:
 
 Django / Python | 3.6 | 3.7 | 3.8
 --------------- | --- | --- | ---  
-2.2  |  *  |  *  |  *   
-3.0  |  *  |  *  |  *  
+2.2             |  *  |  *  |  *   
+3.0             |  *  |  *  |  *  
+4.0             |  *  |  *  |  *  
 
 
 ## Documentation
@@ -271,6 +272,11 @@ Since `bootstrap` template tags and filters are no longer loaded, you'll also ne
 
 
 ## Change Log
+
+### 4.0.1
+
+* Support Django 4.0
+* Avoid extra queries when fetching dismissals #63
 
 ### 4.0.0
 

--- a/runtests.py
+++ b/runtests.py
@@ -18,7 +18,7 @@ DEFAULT_SETTINGS = dict(
         "pinax.announcements.tests",
         "pinax.templates",
     ],
-    MIDDLEWARE = [
+    MIDDLEWARE=[
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "4.0.0"
+VERSION = "4.0.1"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-announcements.svg
     :target: https://pypi.python.org/pypi/pinax-announcements/
@@ -64,6 +64,8 @@ Supported Django and Python Versions
 +-----------------+-----+-----+-----+
 |  3.2            |  *  |  *  |  *  |
 +-----------------+-----+-----+-----+
+|  4.0            |  *  |  *  |  *  |
++-----------------+-----+-----+-----+
 """
 
 setup(
@@ -87,6 +89,7 @@ setup(
         "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,8 @@ show_missing = True
 [tox]
 envlist =
     checkqa,
-    py{36,37,38}-dj{22,30,31,32}
-   
+    py{36,37,38}-dj{22,30,31,32,40}
+
 [testenv]
 passenv = CI CIRCLECI CIRCLE_*
 deps =
@@ -39,6 +39,7 @@ deps =
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0,<4.1
     master: https://github.com/django/django/tarball/master
 
 usedevelop = True


### PR DESCRIPTION
@paltman I'm waiting access to other pinax repositories, e.g: pinax-templates, pinax-ratings, etc.

circle-ci has failed because of permission denied as well:
![Screen Shot 2023-03-23 at 08 42 03](https://user-images.githubusercontent.com/7134451/227077272-cab43680-c19c-4e5a-a135-b85eba617ffe.png)