### PR TITLE
Fixes for Django 4.x

### DIFF
--- a/pinax/announcements/signals.py
+++ b/pinax/announcements/signals.py
@@ -1,5 +1,5 @@
 import django.dispatch
 
-announcement_created = django.dispatch.Signal(providing_args=["announcement", "request"])
-announcement_updated = django.dispatch.Signal(providing_args=["announcement", "request"])
-announcement_deleted = django.dispatch.Signal(providing_args=["announcement", "request"])
+announcement_created = django.dispatch.Signal()
+announcement_updated = django.dispatch.Signal()
+announcement_deleted = django.dispatch.Signal()

--- a/pinax/announcements/urls.py
+++ b/pinax/announcements/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import (
     AnnouncementCreateView,
@@ -12,10 +12,10 @@ from .views import (
 app_name = "pinax_announcements"
 
 urlpatterns = [
-    url(r"^$", AnnouncementListView.as_view(), name="announcement_list"),
-    url(r"^create/$", AnnouncementCreateView.as_view(), name="announcement_create"),
-    url(r"^(?P<pk>\d+)/$", AnnouncementDetailView.as_view(), name="announcement_detail"),
-    url(r"^(?P<pk>\d+)/hide/$", AnnouncementDismissView.as_view(), name="announcement_dismiss"),
-    url(r"^(?P<pk>\d+)/update/$", AnnouncementUpdateView.as_view(), name="announcement_update"),
-    url(r"^(?P<pk>\d+)/delete/$", AnnouncementDeleteView.as_view(), name="announcement_delete"),
+    re_path(r"^$", AnnouncementListView.as_view(), name="announcement_list"),
+    re_path(r"^create/$", AnnouncementCreateView.as_view(), name="announcement_create"),
+    re_path(r"^(?P<pk>\d+)/$", AnnouncementDetailView.as_view(), name="announcement_detail"),
+    re_path(r"^(?P<pk>\d+)/hide/$", AnnouncementDismissView.as_view(), name="announcement_dismiss"),
+    re_path(r"^(?P<pk>\d+)/update/$", AnnouncementUpdateView.as_view(), name="announcement_update"),
+    re_path(r"^(?P<pk>\d+)/delete/$", AnnouncementDeleteView.as_view(), name="announcement_delete"),
 ]

--- a/pinax/announcements/views.py
+++ b/pinax/announcements/views.py
@@ -37,7 +37,8 @@ class AnnouncementDismissView(SingleObjectMixin, View):
         else:
             status = 409
 
-        if request.is_ajax():
+        is_ajax = request.headers.get('x-requested-with') == 'XMLHttpRequest'
+        if is_ajax:
             return JsonResponse({}, status=status)
         else:
             return HttpResponse(content=b"", status=status)


### PR DESCRIPTION
Closes #71 .

---

Implement simple fixes proposed in #71.

According to the Django documentation [here](https://docs.djangoproject.com/en/4.0/topics/signals/), the `kwargs` used in signal `send()` calls in `views.py` should continue to work as-is, so there should be no impact on the API.

Related: #73 