### PR TITLE
use importlib because of setuptools not shipping pkg_resources in later versions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Graham Ullrich <graham@flyingcracker.com>
 Mfon Eti-mfon <mfonetimfon@gmail.com>
 Katherine Michel <kthrnmichel@gmail.com>
 Agus Makmun <summon.agus@gmail.com>
+Nicco Kunzmann <niccokunzmann@rambler.ru>

--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ Since `bootstrap` template tags and filters are no longer loaded, you'll also ne
 
 ## Change Log
 
+### 4.0.2
+
+* use importlib.metadata instead of pkg_resources if available #75
+
 ### 4.0.1
 
 * Support Django 4.0

--- a/pinax/announcements/__init__.py
+++ b/pinax/announcements/__init__.py
@@ -1,3 +1,6 @@
-import pkg_resources
-
-__version__ = pkg_resources.get_distribution("pinax-announcements").version
+try:
+    from importlib.metadata import version
+    __version__ = version("pinax-announcements")
+except ImportError:
+    import pkg_resources
+    __version__ = pkg_resources.get_distribution("pinax-announcements").version

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "4.0.1"
+VERSION = "4.0.2"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-announcements.svg
     :target: https://pypi.python.org/pypi/pinax-announcements/


### PR DESCRIPTION

Closes #75 

Changes proposed in this PR:

- use importlib metadata, available Python 3.8+ for the version

**Tips for an ideal PR**
* You have read our Code of Conduct: https://github.com/pinax/.github/blob/master/CODE_OF_CONDUCT.md
* You have read our Contributing info: https://github.com/pinax/.github/blob/master/CONTRIBUTING.md
* The PR is atomic
* Unit tests have been updated/added, if needed
* App version number has been updated in `setup.py` (Pinax uses [SemVer](https://semver.org/))
* `Change Log` has been updated
* You have added your name to the `AUTHORS` file

